### PR TITLE
Remove Weekly Developer Updates from Blog Page

### DIFF
--- a/components/navigation/SideMenuSideBar.tsx
+++ b/components/navigation/SideMenuSideBar.tsx
@@ -8,7 +8,7 @@ import { ScreenContext } from '../../contexts/screen';
 import {
   collapseSideMenu,
   expandSideMenu,
-  PageType
+  PageType,
 } from '../../state/navigation';
 import { IState } from '../../state/reducers';
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -33,6 +33,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Get tags for pagination
   let tagPosts = [];
   let tagTotalPosts;
+  let filteredPosts = posts;
+  let filteredTotalPosts = totalPosts;
   if (tag) {
     const {
       posts: _tagPosts = [],
@@ -45,14 +47,19 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
+  } else {
+    // Filter out all "Developer Update" blog posts.
+    const DEV_UPDATES = 'dev-update';
+    filteredPosts = posts.filter(post => !post.tags.includes(DEV_UPDATES));
+    filteredTotalPosts = filteredPosts.length;
   }
 
-  const total = tagTotalPosts ?? totalPosts;
+  const total = tagTotalPosts ?? filteredTotalPosts;
   const pageCount = Math.floor(total / CMS.BLOG_RESULTS_PER_PAGE);
 
   return {
     props: {
-      posts,
+      posts: filteredPosts,
       pageCount,
       currentPage: page,
       tag,

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -48,10 +48,17 @@ export const getServerSideProps: GetServerSideProps = async context => {
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
   } else {
-    // Filter out all "Developer Update" blog posts.
-    const DEV_UPDATES = 'dev-update';
-    filteredPosts = posts.filter(post => !post.tags.includes(DEV_UPDATES));
-    filteredTotalPosts = filteredPosts.length;
+    // Retrieve all blog posts without the `dev-update` tag when not searching by tag
+    const {
+      posts: _tagPosts = [],
+      total: _tagTotalPosts,
+    } = await cms.fetchBlogEntriesWithoutDevUpdates(
+      CMS.BLOG_RESULTS_PER_PAGE,
+      page,
+    );
+
+    filteredPosts = _tagPosts;
+    filteredTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;
-  const pageCount = Math.floor(total / CMS.BLOG_RESULTS_PER_PAGE);
+  const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE);
 
   return {
     props: {

--- a/services/cms.tsx
+++ b/services/cms.tsx
@@ -94,6 +94,27 @@ export class CmsApi {
     return { posts: [], total: 0 } as IFetchBlogEntriesReturn;
   }
 
+  public async fetchBlogEntriesWithoutDevUpdates(
+    quantity = CMS.BLOG_RESULTS_PER_PAGE,
+    page = 1,
+  ): Promise<IFetchBlogEntriesReturn> {
+    const DEV_UPDATE_TAG = 'dev-update';
+    const entries = await this.client.getEntries({
+      content_type: 'post', // only fetch blog post entry
+      order: '-fields.date',
+      'fields.tags[ne]': DEV_UPDATE_TAG, // Exclude blog posts with the "dev-update" tag
+      limit: quantity,
+      skip: (page - 1) * quantity,
+    });
+
+    if (entries && entries.items && entries.items.length > 0) {
+      const blogPosts = entries.items.map(entry => this.convertPost(entry));
+      return { posts: blogPosts, total: entries.total };
+    }
+
+    return { posts: [], total: 0 } as IFetchBlogEntriesReturn;
+  }
+
   public async fetchPageEntries(): Promise<TPages> {
     try {
       const entries = await this.client.getEntries({


### PR DESCRIPTION
This PR removes all Weekly Developer Updates from the Blog page. 

Previously, hundreds of developer updates blog posts were included on the blog page, where they really should be in their own section.
![image](https://user-images.githubusercontent.com/46293489/115660373-417fca00-a37f-11eb-940e-cc0ada823020.png)

With this PR, we filter out all developer update blog posts using their associated `tags` attribute, which is an array of strings.
After filtering out all the blog posts. This is what we are left with (notice how all developer blog posts are now shown now).

![image](https://user-images.githubusercontent.com/46293489/115804540-8ca0e800-a426-11eb-906e-e4b53879e51a.png)

To test this:
1. Run the app the `yarn dev`
2. Navigate to the `Blog` Page, all developer updates should be hidden.

Reviewers: @Bilb 