### PR TITLE
Fix Missing Blog Posts Bug

### DIFF
--- a/constants/cms.ts
+++ b/constants/cms.ts
@@ -30,7 +30,8 @@ const CMS = {
     CTA_WHO_USES_OXEN: /^\{\{[\s]*who_uses_oxen[\s]*\}\}$/,
     CTA_SESSION_LOKINET: /^\{\{[\s]*session_lokinet[\s]*\}\}$/,
   },
-  BLOG_RESULTS_PER_PAGE: 21,
+  BLOG_RESULTS_PER_PAGE_MAIN: 21,
+  BLOG_RESULTS_PER_PAGE_TAG: 20,
 };
 
 export default CMS;

--- a/constants/cms.ts
+++ b/constants/cms.ts
@@ -30,8 +30,8 @@ const CMS = {
     CTA_WHO_USES_OXEN: /^\{\{[\s]*who_uses_oxen[\s]*\}\}$/,
     CTA_SESSION_LOKINET: /^\{\{[\s]*session_lokinet[\s]*\}\}$/,
   },
-  BLOG_RESULTS_PER_PAGE_MAIN: 13,
-  BLOG_RESULTS_PER_PAGE_TAG: 12,
+  BLOG_RESULTS_PER_PAGE: 13,
+  BLOG_RESULTS_PER_PAGE_TAGGED: 12,
 };
 
 export default CMS;

--- a/constants/cms.ts
+++ b/constants/cms.ts
@@ -30,7 +30,7 @@ const CMS = {
     CTA_WHO_USES_OXEN: /^\{\{[\s]*who_uses_oxen[\s]*\}\}$/,
     CTA_SESSION_LOKINET: /^\{\{[\s]*session_lokinet[\s]*\}\}$/,
   },
-  BLOG_RESULTS_PER_PAGE: 20,
+  BLOG_RESULTS_PER_PAGE: 21,
 };
 
 export default CMS;

--- a/constants/cms.ts
+++ b/constants/cms.ts
@@ -30,8 +30,8 @@ const CMS = {
     CTA_WHO_USES_OXEN: /^\{\{[\s]*who_uses_oxen[\s]*\}\}$/,
     CTA_SESSION_LOKINET: /^\{\{[\s]*session_lokinet[\s]*\}\}$/,
   },
-  BLOG_RESULTS_PER_PAGE_MAIN: 21,
-  BLOG_RESULTS_PER_PAGE_TAG: 20,
+  BLOG_RESULTS_PER_PAGE_MAIN: 13,
+  BLOG_RESULTS_PER_PAGE_TAG: 12,
 };
 
 export default CMS;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   // Get tag query
   const tag = String(context.query.tag ?? '') ?? null;
-  const page = Math.floor(Number(context.query.page ?? 1));
+  const page = Math.ceil(Number(context.query.page ?? 1));
 
   // Fetch posts even when tag, for related etc
   // Pagination only occurs when tag isnt defined.

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -33,8 +33,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Get tags for pagination
   let tagPosts = [];
   let tagTotalPosts;
-  const filteredPosts = posts;
-  const filteredTotalPosts = totalPosts;
+  let filteredPosts = posts;
+  let filteredTotalPosts = totalPosts;
   let resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE;
   if (tag) {
     const {
@@ -58,8 +58,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
       page,
     );
 
-    // filteredPosts = _tagPosts;
-    // filteredTotalPosts = _tagTotalPosts;
+    filteredPosts = _tagPosts;
+    filteredTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Pagination only occurs when tag isnt defined.
   // If tag is defined, pagination is for tag results
   const { posts, total: totalPosts } = await cms.fetchBlogEntries(
-    tag ? 12 : CMS.BLOG_RESULTS_PER_PAGE_MAIN,
+    tag ? 12 : CMS.BLOG_RESULTS_PER_PAGE,
     tag ? 1 : page,
   );
 
@@ -35,26 +35,26 @@ export const getServerSideProps: GetServerSideProps = async context => {
   let tagTotalPosts;
   const filteredPosts = posts;
   const filteredTotalPosts = totalPosts;
-  let resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_MAIN;
+  let resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE;
   if (tag) {
     const {
       posts: _tagPosts = [],
       total: _tagTotalPosts,
     } = await cms.fetchBlogEntriesByTag(
       tag ?? '',
-      CMS.BLOG_RESULTS_PER_PAGE_TAG,
+      CMS.BLOG_RESULTS_PER_PAGE_TAGGED,
       page,
     );
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
-    resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_TAG;
+    resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_TAGGED;
   } else {
     // Retrieve all blog posts without the `dev-update` tag when not searching by tag
     const {
       posts: _tagPosts = [],
       total: _tagTotalPosts,
     } = await cms.fetchBlogEntriesWithoutDevUpdates(
-      CMS.BLOG_RESULTS_PER_PAGE_MAIN,
+      CMS.BLOG_RESULTS_PER_PAGE,
       page,
     );
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   // Get tag query
   const tag = String(context.query.tag ?? '') ?? null;
-  const page = Math.ceil(Number(context.query.page ?? 1));
+  const page = Math.floor(Number(context.query.page ?? 1));
 
   // Fetch posts even when tag, for related etc
   // Pagination only occurs when tag isnt defined.
@@ -29,6 +29,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     tag ? 8 : CMS.BLOG_RESULTS_PER_PAGE,
     tag ? 1 : page,
   );
+  console.log(posts);
 
   // Get tags for pagination
   let tagPosts = [];
@@ -42,13 +43,13 @@ export const getServerSideProps: GetServerSideProps = async context => {
       CMS.BLOG_RESULTS_PER_PAGE,
       page,
     );
-
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? totalPosts;
-  const pageCount = Math.floor(total / CMS.BLOG_RESULTS_PER_PAGE);
+  console.log(total);
+  const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE);
 
   return {
     props: {
@@ -168,7 +169,7 @@ const Blog = (props: Props) => {
         </Contained>
 
         {/* Posts, or recent posts if tag */}
-        <CardGrid rows={2}>
+        <CardGrid rows={tag ? 2 : 5}>
           {(tag ? posts : otherPosts)?.map(post => (
             <ArticleCard key={post.id} {...post} />
           ))}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Pagination only occurs when tag isnt defined.
   // If tag is defined, pagination is for tag results
   const { posts, total: totalPosts } = await cms.fetchBlogEntries(
-    tag ? 8 : CMS.BLOG_RESULTS_PER_PAGE_MAIN,
+    tag ? 12 : CMS.BLOG_RESULTS_PER_PAGE_MAIN,
     tag ? 1 : page,
   );
 
@@ -35,6 +35,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   let tagTotalPosts;
   const filteredPosts = posts;
   const filteredTotalPosts = totalPosts;
+  let resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_MAIN;
   if (tag) {
     const {
       posts: _tagPosts = [],
@@ -46,6 +47,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     );
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
+    resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_TAG;
   } else {
     // Retrieve all blog posts without the `dev-update` tag when not searching by tag
     const {
@@ -61,7 +63,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;
-  const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE_MAIN);
+  const pageCount = Math.ceil(total / resultsPerPage);
 
   return {
     props: {
@@ -126,8 +128,8 @@ const Blog = (props: Props) => {
             subContainerClassName={''}
             initialPage={currentPage - 1}
             pageCount={pageCount}
-            marginPagesDisplayed={2}
-            pageRangeDisplayed={5}
+            marginPagesDisplayed={1}
+            pageRangeDisplayed={2}
             onPageChange={paginationHandler}
           />
         </div>
@@ -181,7 +183,7 @@ const Blog = (props: Props) => {
         </Contained>
 
         {/* Posts, or recent posts if tag */}
-        <CardGrid rows={tag ? 2 : 5}>
+        <CardGrid>
           {(tag ? posts : otherPosts)?.map(post => (
             <ArticleCard key={post.id} {...post} />
           ))}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -29,7 +29,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
     tag ? 8 : CMS.BLOG_RESULTS_PER_PAGE_MAIN,
     tag ? 1 : page,
   );
-  console.log(posts);
 
   // Get tags for pagination
   let tagPosts = [];
@@ -48,7 +47,6 @@ export const getServerSideProps: GetServerSideProps = async context => {
   }
 
   const total = tagTotalPosts ?? totalPosts;
-  console.log(total);
   const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE_MAIN);
 
   return {

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Pagination only occurs when tag isnt defined.
   // If tag is defined, pagination is for tag results
   const { posts, total: totalPosts } = await cms.fetchBlogEntries(
-    tag ? 8 : CMS.BLOG_RESULTS_PER_PAGE,
+    tag ? 8 : CMS.BLOG_RESULTS_PER_PAGE_MAIN,
     tag ? 1 : page,
   );
   console.log(posts);
@@ -40,7 +40,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
       total: _tagTotalPosts,
     } = await cms.fetchBlogEntriesByTag(
       tag ?? '',
-      CMS.BLOG_RESULTS_PER_PAGE,
+      CMS.BLOG_RESULTS_PER_PAGE_TAG,
       page,
     );
     tagPosts = _tagPosts;
@@ -49,7 +49,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   const total = tagTotalPosts ?? totalPosts;
   console.log(total);
-  const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE);
+  const pageCount = Math.ceil(total / CMS.BLOG_RESULTS_PER_PAGE_MAIN);
 
   return {
     props: {

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -22,11 +22,15 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const tag = String(context.query.tag ?? '') ?? null;
   const page = Math.ceil(Number(context.query.page ?? 1));
 
+  const RESULTS_PER_PAGE = tag
+    ? CMS.BLOG_RESULTS_PER_PAGE_TAGGED
+    : CMS.BLOG_RESULTS_PER_PAGE;
+
   // Fetch posts even when tag, for related etc
   // Pagination only occurs when tag isnt defined.
   // If tag is defined, pagination is for tag results
   const { posts, total: totalPosts } = await cms.fetchBlogEntries(
-    tag ? 12 : CMS.BLOG_RESULTS_PER_PAGE,
+    RESULTS_PER_PAGE,
     tag ? 1 : page,
   );
 
@@ -35,35 +39,26 @@ export const getServerSideProps: GetServerSideProps = async context => {
   let tagTotalPosts;
   let filteredPosts = posts;
   let filteredTotalPosts = totalPosts;
-  let resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE;
   if (tag) {
     const {
       posts: _tagPosts = [],
       total: _tagTotalPosts,
-    } = await cms.fetchBlogEntriesByTag(
-      tag ?? '',
-      CMS.BLOG_RESULTS_PER_PAGE_TAGGED,
-      page,
-    );
+    } = await cms.fetchBlogEntriesByTag(tag ?? '', RESULTS_PER_PAGE, page);
     tagPosts = _tagPosts;
     tagTotalPosts = _tagTotalPosts;
-    resultsPerPage = CMS.BLOG_RESULTS_PER_PAGE_TAGGED;
   } else {
     // Retrieve all blog posts without the `dev-update` tag when not searching by tag
     const {
       posts: _tagPosts = [],
       total: _tagTotalPosts,
-    } = await cms.fetchBlogEntriesWithoutDevUpdates(
-      CMS.BLOG_RESULTS_PER_PAGE,
-      page,
-    );
+    } = await cms.fetchBlogEntriesWithoutDevUpdates(RESULTS_PER_PAGE, page);
 
     filteredPosts = _tagPosts;
     filteredTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;
-  const pageCount = Math.ceil(total / resultsPerPage);
+  const pageCount = Math.ceil(total / RESULTS_PER_PAGE);
 
   return {
     props: {

--- a/services/cms.tsx
+++ b/services/cms.tsx
@@ -32,7 +32,7 @@ export class CmsApi {
   }
 
   public async fetchBlogEntries(
-    quantity = CMS.BLOG_RESULTS_PER_PAGE_MAIN,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const entries = await this.client.getEntries({
@@ -75,7 +75,7 @@ export class CmsApi {
 
   public async fetchBlogEntriesByTag(
     tag: string,
-    quantity = CMS.BLOG_RESULTS_PER_PAGE_TAG,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE_TAGGED,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const entries = await this.client.getEntries({
@@ -95,7 +95,7 @@ export class CmsApi {
   }
 
   public async fetchBlogEntriesWithoutDevUpdates(
-    quantity = CMS.BLOG_RESULTS_PER_PAGE_MAIN,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const DEV_UPDATE_TAG = 'dev-update';

--- a/services/cms.tsx
+++ b/services/cms.tsx
@@ -95,7 +95,7 @@ export class CmsApi {
   }
 
   public async fetchBlogEntriesWithoutDevUpdates(
-    quantity = CMS.BLOG_RESULTS_PER_PAGE,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE_MAIN,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const DEV_UPDATE_TAG = 'dev-update';

--- a/services/cms.tsx
+++ b/services/cms.tsx
@@ -32,7 +32,7 @@ export class CmsApi {
   }
 
   public async fetchBlogEntries(
-    quantity = CMS.BLOG_RESULTS_PER_PAGE,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE_MAIN,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const entries = await this.client.getEntries({
@@ -75,7 +75,7 @@ export class CmsApi {
 
   public async fetchBlogEntriesByTag(
     tag: string,
-    quantity = CMS.BLOG_RESULTS_PER_PAGE,
+    quantity = CMS.BLOG_RESULTS_PER_PAGE_TAG,
     page = 1,
   ): Promise<IFetchBlogEntriesReturn> {
     const entries = await this.client.getEntries({


### PR DESCRIPTION
This PR addresses the following bugs:
### Not all blog posts on a page are shown, resulting in a few blog posts being seemingly 'missing'.

Below are two screenshots depicting page 1 and page 2 of the blog section in the app.

![image](https://user-images.githubusercontent.com/46293489/116030906-fb3caa80-a69f-11eb-8270-934c586ade3c.png)
![image](https://user-images.githubusercontent.com/46293489/116030933-08f23000-a6a0-11eb-9c4b-569748eb08cf.png)

Notice how certain blog posts are missing between page 1 and page 2.

Previously, only 2 rows of blog posts (8 blog posts on desktop) were being shown when a user navigates to the blog page on desktop, despite the code retrieving 20 blog posts. 

To fix this, we simply update the number of rows that are displayed by the `CardGrid` component, which was previously hardcoded to only display `2` rows. By omitting this number, the `CardGrid` component will dynamically decide on the number of rows to actually display.

Also, since we also need to feature 1 blog post on the main Blog Page, we actually need to retrieve 1 additional blog post (21 blog posts) when users navigate to the main blog page, and `20` blog posts when users search for blogs via tags.

--------------------------------------------------

### Inconsistent number of blogs shown between Desktop and Tablet versions

Besides the aforementioned issue, I've also noticed a disparity between the number of posts displayed on the Desktop and Tablet versions of the site. The desktop version displays 4 blog posts per row, while the table version displays 3 blog posts per row.

On Desktop, there are 4 blog posts per row
![image](https://user-images.githubusercontent.com/46293489/116030810-bfa1e080-a69f-11eb-94ea-b644ebff5f98.png)

On Tablet, there are only 3 blog posts per row
![image](https://user-images.githubusercontent.com/46293489/116030733-96815000-a69f-11eb-80cc-12eb95e1d122.png)

To ensure consistency between the number of blog posts retrieved on both desktop and tablet versions, we update the total number of rows to be a number that is a multiple of 3 and 4, with the lowest being `12` blog posts.

12 blogs posts on desktop
![image](https://user-images.githubusercontent.com/46293489/116032394-f1687680-a6a2-11eb-85fc-f450a56330b7.png)

12 blog posts on tablet (image is stretched here to display all 12 blog posts)
![image](https://user-images.githubusercontent.com/46293489/116032485-25439c00-a6a3-11eb-9fdb-5142822f7187.png)

This basically ensures that all retrieved blog posts can be fitted into the space given.

