### PR TITLE
Update Blog Page Pagination

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -5,10 +5,6 @@
 /* ********************* */
 /* ***** CONSTANTS ***** */
 /* ********************* */
-$theme-primary: #fe4c00;
-$theme-primary-2: #eb5929;
-$theme-secondary: #ffd618;
-$theme-secondary-1: #ffd400;
 
 /* **************************** */
 /* ******** RESPONSIVE ******** */

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -151,6 +151,9 @@ body {
 
     &:hover {
       filter: brightness(0.9);
+      &:not(.active) {
+        color: theme('colors.secondary')
+      }
     }
 
     a {
@@ -170,4 +173,3 @@ body {
 ul li > p {
   margin-bottom: 0 !important;
 }
-

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -135,6 +135,10 @@ body {
   border-radius: 4px;
 
   li {
+    & ~ li {
+      border-left: 0.5px solid white;
+    }
+
     &:first-child {
       border-top-left-radius: 0.25rem;
       border-bottom-left-radius: 0.25rem;
@@ -150,13 +154,15 @@ body {
     }
 
     a {
-      padding: 0.5rem 1rem;
+      padding: 0.25rem 0.9rem;
       cursor: pointer;
       width: max-content;
       height: auto;
       font-weight: 500;
     }
 
+    display: flex;
+    align-items: center;
     border-radius: 0;
   }
 }
@@ -165,6 +171,3 @@ ul li > p {
   margin-bottom: 0 !important;
 }
 
-.apple {
-  color: red;
-}

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -150,12 +150,13 @@ body {
     }
 
     a {
-      padding: 0.25rem 1rem;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
       width: max-content;
+      height: auto;
+      font-weight: 500;
     }
-    cursor: pointer;
-    width: max-content;
-    font-weight: 500;
+
     border-radius: 0;
   }
 }

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -149,8 +149,11 @@ body {
       filter: brightness(0.9);
     }
 
+    a {
+      padding: 0.25rem 1rem;
+      width: max-content;
+    }
     cursor: pointer;
-    padding: 0.25rem 1rem;
     width: max-content;
     font-weight: 500;
     border-radius: 0;
@@ -159,4 +162,8 @@ body {
 
 ul li > p {
   margin-bottom: 0 !important;
+}
+
+.apple {
+  color: red;
 }

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -120,7 +120,6 @@ const Blog = (props: Props) => {
             breakClassName={'break-me'}
             activeClassName={'active bg-secondary'}
             containerClassName={'pagination bg-primary text-white front-prompt'}
-            pageLinkClassName={''}
             initialPage={currentPage - 1}
             pageCount={pageCount}
             marginPagesDisplayed={1}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -33,8 +33,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Get tags for pagination
   let tagPosts = [];
   let tagTotalPosts;
-  let filteredPosts = posts;
-  let filteredTotalPosts = totalPosts;
+  const filteredPosts = posts;
+  const filteredTotalPosts = totalPosts;
   if (tag) {
     const {
       posts: _tagPosts = [],
@@ -57,8 +57,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
       page,
     );
 
-    filteredPosts = _tagPosts;
-    filteredTotalPosts = _tagTotalPosts;
+    // filteredPosts = _tagPosts;
+    // filteredTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;
@@ -124,7 +124,7 @@ const Blog = (props: Props) => {
             breakClassName={'break-me'}
             activeClassName={'active bg-secondary'}
             containerClassName={'pagination bg-primary text-white front-prompt'}
-            subContainerClassName={''}
+            pageLinkClassName={'apple'}
             initialPage={currentPage - 1}
             pageCount={pageCount}
             marginPagesDisplayed={2}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -124,7 +124,7 @@ const Blog = (props: Props) => {
             breakClassName={'break-me'}
             activeClassName={'active bg-secondary'}
             containerClassName={'pagination bg-primary text-white front-prompt'}
-            pageLinkClassName={'apple'}
+            pageLinkClassName={''}
             initialPage={currentPage - 1}
             pageCount={pageCount}
             marginPagesDisplayed={2}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -33,8 +33,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
   // Get tags for pagination
   let tagPosts = [];
   let tagTotalPosts;
-  const filteredPosts = posts;
-  const filteredTotalPosts = totalPosts;
+  let filteredPosts = posts;
+  let filteredTotalPosts = totalPosts;
   if (tag) {
     const {
       posts: _tagPosts = [],
@@ -57,8 +57,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
       page,
     );
 
-    // filteredPosts = _tagPosts;
-    // filteredTotalPosts = _tagTotalPosts;
+    filteredPosts = _tagPosts;
+    filteredTotalPosts = _tagTotalPosts;
   }
 
   const total = tagTotalPosts ?? filteredTotalPosts;


### PR DESCRIPTION
This PR fixes the following issue:
Previously on the Blog Page, users had to click on the pagination text number (e.g. 1, 2, 3, ...) in order to navigate to other sections of the blog.

e.g. Previously, we had to click on the text in the buttons themselves to navigate to another page, and clicking in the general area of the button didn't bring us to that page, resulting in a non-optimal user experience.
![image](https://user-images.githubusercontent.com/46293489/116492302-47296280-a8df-11eb-9eed-2830c3c8558f.png)

With this fix, users can now click on the general area of the button, instead of the text itself, resulting in a better UI/UX experience. 

A border between each button has also been added.

![image](https://user-images.githubusercontent.com/46293489/116490568-0d565d00-a8db-11eb-9f86-066d79b51421.png)

I've also updated the hover color on inactive pagination buttons, as the previous color wasn't really visible.
![image](https://user-images.githubusercontent.com/46293489/116490727-67efb900-a8db-11eb-98c6-c786cebbdbff.png)

