### PR TITLE
Update Side Menu Design & Styling

### DIFF
--- a/components/navigation/SideMenuFullscreen.tsx
+++ b/components/navigation/SideMenuFullscreen.tsx
@@ -28,8 +28,6 @@ export function SideMenuFullscreen({ withSideBar }: Props) {
                 : ''
             }`,
       }}
-      //{/* Update padding for navigation  */}
-
       className={classNames('fixed inset-0 flex duration-300 transform bg-alt')}
     >
       <div className="flex flex-col w-full space-y-4">

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -105,7 +105,7 @@ export function SideMenuInner() {
 }
 
 const SocialsRow = () => {
-  const { isDesktop, isTablet } = useContext(ScreenContext);
+  const { isTablet } = useContext(ScreenContext);
 
   return (
     <div

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -59,7 +59,7 @@ export function SideMenuInner() {
           {!isDesktop && (
             <div
               className={classNames(
-                'flex flex-col pt-8 font-medium uppercase font-prompt text-lg',
+                'flex flex-col pt-8 pl-6 font-medium uppercase font-prompt text-lg',
               )}
             >
               {_.chunk(NAVIGATION.MENU_ITEMS, 2).map(group => (
@@ -105,13 +105,13 @@ export function SideMenuInner() {
 }
 
 const SocialsRow = () => {
-  const { isDesktop } = useContext(ScreenContext);
+  const { isDesktop, isTablet } = useContext(ScreenContext);
 
   return (
     <div
       className={classNames(
-        'flex pt-3 pb-3 space-x-3',
-        isDesktop ? 'justify-between' : 'justify-start pl-6',
+        'flex pt-3 pb-3',
+        isTablet ? 'justify-start space-x-3 px-6' : 'justify-between',
       )}
     >
       <a href="https://t.me/Oxen_Community" target="_blank" rel="noreferrer">

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -111,7 +111,7 @@ const SocialsRow = () => {
     <div
       className={classNames(
         'flex pt-3 pb-3',
-        isTablet ? 'justify-start space-x-3 px-6' : 'justify-between',
+        isTablet ? 'justify-start space-x-5 px-6' : 'justify-between',
       )}
     >
       <a href="https://t.me/Oxen_Community" target="_blank" rel="noreferrer">

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -110,8 +110,8 @@ const SocialsRow = () => {
   return (
     <div
       className={classNames(
-        'flex pt-3 pb-3 space-x-3 justify-between',
-        isDesktop && 'justify-between',
+        'flex pt-3 pb-3 space-x-3',
+        isDesktop ? 'justify-between' : 'justify-start pl-6',
       )}
     >
       <a href="https://t.me/Oxen_Community" target="_blank" rel="noreferrer">

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -92,15 +92,6 @@ export function SideMenuInner() {
                 <img className="h-5" src="/img/coingecko.png" />
                 <span>CoinGecko</span>
               </a>
-              <a
-                href="https://coinmarketcap.com/currencies/oxen/"
-                target="_blank"
-                rel="dofollow"
-                className="flex items-center mx-2 space-x-1 font-bold hover:underline"
-              >
-                <img className="h-5" src="/img/coinmarketcap.png" />
-                <span>CMC</span>
-              </a>
             </div>
           </div>
         </div>

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -80,7 +80,7 @@ export function SideMenuInner() {
         <div className="px-6 pb-3">
           <SocialsRow />
 
-          <div className="flex items-center justify-between font-medium text-secondary whitespace-nowrap">
+          <div className="flex items-center justify-end font-medium text-secondary whitespace-nowrap">
             View Oxen on{' '}
             <div className="flex items-center">
               <a


### PR DESCRIPTION
This PR introduces a few changes to the side menu design.

After:
![image](https://user-images.githubusercontent.com/46293489/116651307-44556d00-a9c6-11eb-9cce-9bc45d4ec660.png)

Most notable changes:
**- Remove CMC Logo and Link**
Also aligns the "View Oxen on" text to the right.
![image](https://user-images.githubusercontent.com/46293489/116651237-1b34dc80-a9c6-11eb-80e0-0f06507f65cf.png)

**- Aligns the navigation bar links to the side menu items (for Tablet and Mobile Versions)**

Tablet
For the tablet version, the placement for the social buttons have been updated as well for a more cleaner look
![image](https://user-images.githubusercontent.com/46293489/116651378-6bac3a00-a9c6-11eb-8d00-dc25b9e1b4c9.png)

Mobile
![image](https://user-images.githubusercontent.com/46293489/116651429-88e10880-a9c6-11eb-9671-fccb1f2cf8a6.png)
