### PR TITLE
Add Metatags to Improve SEO Score

### DIFF
--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -86,7 +86,7 @@ export function SideMenuInner() {
               <a
                 href="https://www.coingecko.com/en/coins/oxen"
                 target="_blank"
-                rel="dofollow"
+                rel="nofollow"
                 className="flex items-center mx-2 space-x-1 font-bold hover:underline"
               >
                 <img className="h-5" src="/img/coingecko.png" />

--- a/constants/metadata.tsx
+++ b/constants/metadata.tsx
@@ -4,7 +4,7 @@ const METADATA = {
   SITE_META_DESCRIPTION:
     'Oxen is built by the OPTF, a passionate team of advocates, creatives, and engineers building a world where the internet is open, software is free and accessible, and your privacy is protected. The OPTF also builds other platforms using Oxen technology, and supports other developers in building on Oxen.',
   ROADMAP: {
-    DESCRIPTION: "View Oxen's plan for the futere here.",
+    DESCRIPTION: "View Oxen's plan for the future here.",
   },
   404: {
     DESCRIPTION: "Oopsy, here's our 404 page.",

--- a/constants/metadata.tsx
+++ b/constants/metadata.tsx
@@ -9,6 +9,10 @@ const METADATA = {
   404: {
     DESCRIPTION: "Oopsy, here's our 404 page.",
   },
+  BLOG: {
+    DESCRIPTION: "View Oxen's Blog Updates Here",
+    URL: 'https://oxen.io/blog',
+  },
 };
 
 export default METADATA;

--- a/constants/metadata.tsx
+++ b/constants/metadata.tsx
@@ -6,6 +6,9 @@ const METADATA = {
   ROADMAP: {
     DESCRIPTION: "View Oxen's plan for the futere here.",
   },
+  404: {
+    DESCRIPTION: "Oopsy, here's our 404 page.",
+  },
 };
 
 export default METADATA;

--- a/constants/metadata.tsx
+++ b/constants/metadata.tsx
@@ -1,6 +1,11 @@
 const METADATA = {
   OXEN_HOST_URL: 'https://oxen.io',
   TITLE_SUFFIX: 'Oxen | Privacy made simple.',
+  SITE_META_DESCRIPTION:
+    'Oxen is built by the OPTF, a passionate team of advocates, creatives, and engineers building a world where the internet is open, software is free and accessible, and your privacy is protected. The OPTF also builds other platforms using Oxen technology, and supports other developers in building on Oxen.',
+  ROADMAP: {
+    DESCRIPTION: "View Oxen's plan for the futere here.",
+  },
 };
 
 export default METADATA;

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -123,7 +123,7 @@ const NAVIGATION = {
   BLOG_REGEX: /^\/(blog)([?tag=[\w-]*)?([?&]page=[0-9]{1,3})?/,
   POST_REGEX: /^\/(blog\/)(([\w-]{1,100})|(\[slug\]))$/,
   SITE_META_DESCRIPTION:
-    'Oxen is built by the Loki Foundation, a passionate team of advocates, creatives, and engineers building a world where the internet is open, software is free and accessible, and your privacy is protected. The Loki Foundation also builds other platforms using Oxen technology, and supports other developers in building on Oxen.',
+    'Oxen is built by the OPTF, a passionate team of advocates, creatives, and engineers building a world where the internet is open, software is free and accessible, and your privacy is protected. The OPTF also builds other platforms using Oxen technology, and supports other developers in building on Oxen.',
 };
 
 export default NAVIGATION;

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -122,8 +122,6 @@ const NAVIGATION = {
   SIDE_MENU_ITEMS,
   BLOG_REGEX: /^\/(blog)([?tag=[\w-]*)?([?&]page=[0-9]{1,3})?/,
   POST_REGEX: /^\/(blog\/)(([\w-]{1,100})|(\[slug\]))$/,
-  SITE_META_DESCRIPTION:
-    'Oxen is built by the OPTF, a passionate team of advocates, creatives, and engineers building a world where the internet is open, software is free and accessible, and your privacy is protected. The OPTF also builds other platforms using Oxen technology, and supports other developers in building on Oxen.',
 };
 
 export default NAVIGATION;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,9 +2,9 @@ import classNames from 'classnames';
 import Head from 'next/head';
 import React, { useContext } from 'react';
 // import _404 from '../assets/svgs/404.svg';
-import { UI } from '../constants';
+import { UI, METADATA } from '../constants';
 import { ScreenContext } from '../contexts/screen';
-import { generateTitle } from '../utils/metadata';
+import { generateTitle, generateURL } from '../utils/metadata';
 
 function oxen404() {
   const { isMobile, isTablet, isDesktop, isHuge } = useContext(ScreenContext);
@@ -47,10 +47,25 @@ function oxen404() {
     width: '9rem',
   };
 
+  const pageTitle = generateTitle('404');
+  const pageURL = generateURL('/404');
+
   return (
     <div className="flex items-center justify-center flex-grow h-full">
       <Head>
-        <title>{generateTitle('404')}</title>
+        <title>{pageTitle}</title>
+        <meta name="description" content={METADATA['404'].DESCRIPTION}></meta>
+        <meta property="og:title" content={pageTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={METADATA['404'].DESCRIPTION}
+          key="ogdesc"
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
+        <meta property="og:url" content={pageURL} />
+
+        <link rel="canonical" href={pageURL}></link>
       </Head>
 
       <div style={wrapperStyles} className="flex items-center flex-grow">
@@ -65,13 +80,13 @@ function oxen404() {
             <div style={_404SectionStyles} className="absolute left-0 z-50">
               <h1
                 style={_404TitleStyles}
-                className="-mb-4 text-opacity-25 font-sans text-primary text-8xl"
+                className="-mb-4 font-sans text-opacity-25 text-primary text-8xl"
               >
                 404
               </h1>
               <p
                 style={_404TextStyles}
-                className="text-4xl tracking-tight font-sans text-primary"
+                className="font-sans text-4xl tracking-tight text-primary"
               >
                 Nothing found here.
               </p>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -62,7 +62,6 @@ function oxen404() {
           key="ogdesc"
         />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
         <meta property="og:url" content={pageURL} />
 
         <link rel="canonical" href={pageURL}></link>

--- a/pages/[page].tsx
+++ b/pages/[page].tsx
@@ -24,23 +24,20 @@ export async function getStaticPaths() {
       params: { page: item.href },
     }),
   );
-  console.debug(paths);
 
   return { paths, fallback: true };
 }
 
 export async function getStaticProps({ params }) {
   const href = params?.page ?? '';
-  console.debug(params);
   const id = unslugify(String(href));
-  console.debug(href);
   // Roadmap page is special 👁️👄👁️
   if (SideMenuItem[id] == [SideMenuItem.ROADMAP]) {
     return {
       props: {
         page: null,
         isRoadmap: true,
-        href: `/${href}`,
+        href: `/${href}`, // the '/' is removed from the href from getStaticPaths(), so let's add it back here
       },
       revalidate: 60,
     };
@@ -89,7 +86,6 @@ function Page({
     isRoadmap ? NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].href : href,
   );
 
-  console.debug(href);
   return (
     <>
       <Head>

--- a/pages/[page].tsx
+++ b/pages/[page].tsx
@@ -110,6 +110,10 @@ function Page({
         <meta property="og:url" content={pageURL} />
 
         <link rel="canonical" href={pageURL}></link>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={pageDescription} />
+        <meta name="twitter:image" content={page?.hero?.imageUrl} />
       </Head>
 
       <div className="bg-alt">

--- a/pages/[page].tsx
+++ b/pages/[page].tsx
@@ -4,11 +4,11 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Contained } from '../components/Contained';
 import { RichBody } from '../components/RichBody';
-import { NAVIGATION } from '../constants';
+import { NAVIGATION, METADATA } from '../constants';
 import { CmsApi, unslugify } from '../services/cms';
 import { PageType, setPageType, SideMenuItem } from '../state/navigation';
 import { ISplitPage } from '../types/cms';
-import { generateTitle } from '../utils/metadata';
+import { generateTitle, generateURL } from '../utils/metadata';
 
 interface IPath {
   params: { page: string; isRoadmap?: boolean };
@@ -19,25 +19,28 @@ export async function getStaticPaths() {
   // Hardcoded in navigation constants.
   // Contentful can edit entries but cannot add/remove
   // without touching code.
-
   const paths: IPath[] = Object.values(NAVIGATION.SIDE_MENU_ITEMS).map(
     item => ({
       params: { page: item.href },
     }),
   );
+  console.debug(paths);
 
   return { paths, fallback: true };
 }
 
 export async function getStaticProps({ params }) {
-  const id = unslugify(String(params?.page) ?? '');
-
+  const href = params?.page ?? '';
+  console.debug(params);
+  const id = unslugify(String(href));
+  console.debug(href);
   // Roadmap page is special 👁️👄👁️
   if (SideMenuItem[id] == [SideMenuItem.ROADMAP]) {
     return {
       props: {
         page: null,
         isRoadmap: true,
+        href: `/${href}`,
       },
       revalidate: 60,
     };
@@ -45,7 +48,6 @@ export async function getStaticProps({ params }) {
 
   const cms = new CmsApi();
   const page = await cms.fetchPageById(SideMenuItem[id]);
-
   if (!page) {
     return { notFound: true };
   }
@@ -54,6 +56,7 @@ export async function getStaticProps({ params }) {
     props: {
       page,
       isRoadmap: false,
+      href: `/${href}`,
     },
     revalidate: 60,
   };
@@ -62,25 +65,51 @@ export async function getStaticProps({ params }) {
 function Page({
   page,
   isRoadmap,
+  href,
 }: {
   page: ISplitPage | null;
   isRoadmap?: boolean;
+  href: string;
 }) {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(setPageType(PageType.NORMAL));
   }, []);
+  const pageTitle = generateTitle(
+    isRoadmap
+      ? NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].label
+      : page?.label,
+  );
 
+  const pageDescription = isRoadmap
+    ? METADATA.ROADMAP.DESCRIPTION
+    : page?.title;
+
+  const pageURL = generateURL(
+    isRoadmap ? NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].href : href,
+  );
+
+  console.debug(href);
   return (
     <>
       <Head>
-        <title>
-          {generateTitle(
-            isRoadmap
-              ? NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].label
-              : page?.label,
-          )}
-        </title>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription}></meta>
+        <meta property="og:title" content={pageTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={pageDescription}
+          key="ogdesc"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:image"
+          content={page?.hero?.imageUrl}
+          key="ogimage"
+        />
+        <meta property="og:url" content={pageURL} />
+
+        <link rel="canonical" href={pageURL}></link>
       </Head>
 
       <div className="bg-alt">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,6 +63,7 @@ function App({ Component, pageProps }: AppProps) {
               name="viewport"
               content="width=device-width, initial-scale=1, maximum-scale=1"
             ></meta>
+            <meta name="apple-itunes-app" content="app-id=1547745078" />
           </Head>
 
           <Layout>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,6 +63,8 @@ function App({ Component, pageProps }: AppProps) {
               name="viewport"
               content="width=device-width, initial-scale=1, maximum-scale=1"
             ></meta>
+            <meta property="og:site_name" content="Oxen" key="ogsitename" />
+            <meta property="og:locale" content="en_US" />
             <meta name="apple-itunes-app" content="app-id=1547745078" />
           </Head>
 

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -43,7 +43,7 @@ export async function getStaticProps({ params }) {
 
   const cms = new CmsApi();
   const post = await cms.fetchBlogBySlug(String(params?.slug) ?? '');
-  const url = generateURL(`/blog/${params.slug}`);
+  const url = generateURL(params?.slug ? `/blog/${params?.slug}` : '/blog');
   if (!post) {
     return { notFound: true };
   }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -43,7 +43,7 @@ export async function getStaticProps({ params }) {
 
   const cms = new CmsApi();
   const post = await cms.fetchBlogBySlug(String(params?.slug) ?? '');
-
+  const url = generateURL(`/blog/${params.slug}`);
   if (!post) {
     return { notFound: true };
   }
@@ -51,13 +51,14 @@ export async function getStaticProps({ params }) {
   return {
     props: {
       post,
+      url,
     },
     revalidate: 60,
   };
 }
 
 // Parallax on bg as mouse moves
-function Post({ post }: { post: IPost }) {
+function Post({ post, url }: { post: IPost; url: string }) {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -71,7 +72,14 @@ function Post({ post }: { post: IPost }) {
     <>
       <Head>
         <title>{pageTitle}</title>
-
+        <meta name="description" content={post?.description}></meta>
+        <meta property="og:title" content={pageTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={post?.description}
+          key="ogdesc"
+        />
+        <meta property="og:type" content="article" />
         <meta name="image_src" content={post?.featureImage?.imageUrl} />
         <meta name="image_url" content={post?.featureImage?.imageUrl} />
         <meta name="keywords" content={post?.tags?.join(' ')} />
@@ -80,14 +88,8 @@ function Post({ post }: { post: IPost }) {
           content={post?.featureImage?.imageUrl}
           key="ogimage"
         />
-
-        <meta property="og:site_name" content="oxen.io" key="ogsitename" />
-        <meta property="og:title" content={pageTitle} key="ogtitle" />
-        <meta
-          property="og:description"
-          content={post?.description}
-          key="ogdesc"
-        />
+        <meta property="og:url" content={url} />
+        <link rel="canonical" href={url}></link>{' '}
       </Head>
 
       <div className="bg-alt">

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -67,6 +67,7 @@ function Post({ post, url }: { post: IPost; url: string }) {
   }, []);
 
   const pageTitle = generateTitle(post?.title);
+  const imageURL = post?.featureImage?.imageUrl;
 
   return (
     <>
@@ -80,16 +81,16 @@ function Post({ post, url }: { post: IPost; url: string }) {
           key="ogdesc"
         />
         <meta property="og:type" content="article" />
-        <meta name="image_src" content={post?.featureImage?.imageUrl} />
-        <meta name="image_url" content={post?.featureImage?.imageUrl} />
+        <meta name="image_src" content={imageURL} />
+        <meta name="image_url" content={imageURL} />
         <meta name="keywords" content={post?.tags?.join(' ')} />
-        <meta
-          property="og:image"
-          content={post?.featureImage?.imageUrl}
-          key="ogimage"
-        />
+        <meta property="og:image" content={imageURL} key="ogimage" />
         <meta property="og:url" content={url} />
         <link rel="canonical" href={url}></link>{' '}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={post?.description} />
+        <meta name="twitter:image" content={imageURL} />
       </Head>
 
       <div className="bg-alt">

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -6,7 +6,7 @@ import { Article } from '../../components/article/Article';
 import { CmsApi } from '../../services/cms';
 import { PageType, setPageType, setPostTitle } from '../../state/navigation';
 import { IPost } from '../../types/cms';
-import { generateTitle } from '../../utils/metadata';
+import { generateTitle, generateURL } from '../../utils/metadata';
 
 interface IPath {
   params: { slug: string };

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -132,6 +132,7 @@ const Blog = (props: Props) => {
   );
 
   const pageTitle = generateTitle('Blog');
+  const featuredImageURL = featuredPost?.featureImage?.imageUrl;
 
   return (
     <div>
@@ -145,13 +146,13 @@ const Blog = (props: Props) => {
           key="ogdesc"
         />
         <meta property="og:type" content="website" />
-        <meta
-          property="og:image"
-          content={featuredPost?.featureImage?.imageUrl}
-          key="ogimage"
-        />
+        <meta property="og:image" content={featuredImageURL} key="ogimage" />
         <meta property="og:url" content={METADATA.BLOG.URL} />
         <link rel="canonical" href={METADATA.BLOG.URL}></link>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={METADATA.BLOG.DESCRIPTION} />
+        <meta name="twitter:image" content={featuredImageURL} />
       </Head>
 
       <div className="flex flex-col w-full mt-12 mb-6 space-y-6 bg-alt">

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -135,6 +135,7 @@ const Blog = (props: Props) => {
     <div>
       <Head>
         <title>{generateTitle('Blog')}</title>
+        {/* TODO: Update metatags here (name, description, image?) */}
       </Head>
 
       <div className="flex flex-col w-full mt-12 mb-6 space-y-6 bg-alt">

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -9,7 +9,7 @@ import { ArticleCardFeature } from '../../components/cards/ArticleCardFeature';
 import { CardGrid } from '../../components/cards/CardGrid';
 import { Contained } from '../../components/Contained';
 import { TagBlock } from '../../components/TagBlock';
-import { CMS } from '../../constants';
+import { CMS, METADATA } from '../../constants';
 import { CmsApi } from '../../services/cms';
 import { PageType, setPageType } from '../../state/navigation';
 import { IPost } from '../../types/cms';
@@ -131,11 +131,27 @@ const Blog = (props: Props) => {
     </Contained>
   );
 
+  const pageTitle = generateTitle('Blog');
+
   return (
     <div>
       <Head>
-        <title>{generateTitle('Blog')}</title>
-        {/* TODO: Update metatags here (name, description, image?) */}
+        <title>{pageTitle}</title>
+        <meta name="description" content={METADATA.BLOG.DESCRIPTION}></meta>
+        <meta property="og:title" content={pageTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={METADATA.BLOG.DESCRIPTION}
+          key="ogdesc"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:image"
+          content={featuredPost?.featureImage?.imageUrl}
+          key="ogimage"
+        />
+        <meta property="og:url" content={METADATA.BLOG.URL} />
+        <link rel="canonical" href={METADATA.BLOG.URL}></link>{' '}
       </Head>
 
       <div className="flex flex-col w-full mt-12 mb-6 space-y-6 bg-alt">

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -151,7 +151,7 @@ const Blog = (props: Props) => {
           key="ogimage"
         />
         <meta property="og:url" content={METADATA.BLOG.URL} />
-        <link rel="canonical" href={METADATA.BLOG.URL}></link>{' '}
+        <link rel="canonical" href={METADATA.BLOG.URL}></link>
       </Head>
 
       <div className="flex flex-col w-full mt-12 mb-6 space-y-6 bg-alt">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,13 @@ const Index = () => {
           key="title"
         />
         <meta property="og:image" content={'site-banner.png'} key="ogimage" />
-        <meta property="og:site_name" content="oxen.io" key="ogsitename" />
-        <meta property="og:title" content={'Oxen'} key="ogtitle" />
+        <meta property="og:site_name" content="Oxen" key="ogsitename" />
+        <meta property="og:type" content="website"></meta>
+        <meta
+          property="og:title"
+          content={'Oxen - Privacy should be simple.'}
+          key="ogtitle"
+        />
         <meta
           name="description"
           content={NAVIGATION.SITE_META_DESCRIPTION}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,10 +18,15 @@ const Index = () => {
         <meta property="og:site_name" content="oxen.io" key="ogsitename" />
         <meta property="og:title" content={'Oxen'} key="ogtitle" />
         <meta
+          name="description"
+          content={NAVIGATION.SITE_META_DESCRIPTION}
+        ></meta>
+        <meta
           property="og:description"
           content={NAVIGATION.SITE_META_DESCRIPTION}
           key="ogdesc"
         />
+        <meta name="apple-itunes-app" content="app-id=1547745078" />
       </Head>
 
       {/* Only visible when no pages are open */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { HomeHeroBubble } from '../components/HomeHeroBubble';
 import { METADATA } from '../constants';
 
 const Index = () => {
+  const imageURL = `${METADATA.OXEN_HOST_URL}/site-banner.png`;
   return (
     <>
       <Head>
@@ -24,7 +25,7 @@ const Index = () => {
           key="ogdesc"
         />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
+        <meta property="og:image" content={imageURL} key="ogimage" />
         <meta property="og:url" content={METADATA.OXEN_HOST_URL} />
 
         <link rel="canonical" href={METADATA.OXEN_HOST_URL}></link>
@@ -34,7 +35,7 @@ const Index = () => {
           name="twitter:description"
           content={METADATA.SITE_META_DESCRIPTION}
         />
-        <meta name="twitter:image" content={'site-banner.png'} />
+        <meta name="twitter:image" content={imageURL} />
       </Head>
 
       {/* Only visible when no pages are open */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,6 +32,7 @@ const Index = () => {
           key="ogdesc"
         />
         <meta name="apple-itunes-app" content="app-id=1547745078" />
+        <link rel="canonical" href="https://oxen.io/"></link>
       </Head>
 
       {/* Only visible when no pages are open */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,13 @@ const Index = () => {
         <meta property="og:url" content={METADATA.OXEN_HOST_URL} />
 
         <link rel="canonical" href={METADATA.OXEN_HOST_URL}></link>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={METADATA.TITLE_SUFFIX} />
+        <meta
+          name="twitter:description"
+          content={METADATA.SITE_META_DESCRIPTION}
+        />
+        <meta name="twitter:image" content={'site-banner.png'} />
       </Head>
 
       {/* Only visible when no pages are open */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,14 +9,10 @@ const Index = () => {
     <>
       <Head>
         <title>{METADATA.TITLE_SUFFIX}</title>
-        <meta
-          property="og:title"
-          content="Oxen - Privacy should be simple."
-          key="title"
-        />
         <meta property="og:image" content={'site-banner.png'} key="ogimage" />
         <meta property="og:site_name" content="Oxen" key="ogsitename" />
         <meta property="og:type" content="website"></meta>
+        <meta property="og:url" content={METADATA.OXEN_HOST_URL}></meta>
         <meta
           property="og:title"
           content={'Oxen - Privacy should be simple.'}
@@ -31,7 +27,6 @@ const Index = () => {
           content={NAVIGATION.SITE_META_DESCRIPTION}
           key="ogdesc"
         />
-        <meta name="apple-itunes-app" content="app-id=1547745078" />
         <link rel="canonical" href="https://oxen.io/"></link>
       </Head>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import React from 'react';
 import { HomeHero } from '../components/HomeHero';
 import { HomeHeroBubble } from '../components/HomeHeroBubble';
-import { METADATA, NAVIGATION } from '../constants';
+import { METADATA } from '../constants';
 
 const Index = () => {
   return (
@@ -11,7 +11,7 @@ const Index = () => {
         <title>{METADATA.TITLE_SUFFIX}</title>
         <meta
           name="description"
-          content={NAVIGATION.SITE_META_DESCRIPTION}
+          content={METADATA.SITE_META_DESCRIPTION}
         ></meta>
         <meta
           property="og:title"
@@ -20,14 +20,14 @@ const Index = () => {
         />
         <meta
           property="og:description"
-          content={NAVIGATION.SITE_META_DESCRIPTION}
+          content={METADATA.SITE_META_DESCRIPTION}
           key="ogdesc"
         />
         <meta property="og:type" content="website" />
         <meta property="og:image" content={'site-banner.png'} key="ogimage" />
         <meta property="og:url" content={METADATA.OXEN_HOST_URL} />
 
-        <link rel="canonical" href="https://oxen.io/"></link>
+        <link rel="canonical" href={METADATA.OXEN_HOST_URL}></link>
       </Head>
 
       {/* Only visible when no pages are open */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,6 @@ const Index = () => {
       <Head>
         <title>{METADATA.TITLE_SUFFIX}</title>
         <meta property="og:image" content={'site-banner.png'} key="ogimage" />
-        <meta property="og:site_name" content="Oxen" key="ogsitename" />
         <meta property="og:type" content="website"></meta>
         <meta property="og:url" content={METADATA.OXEN_HOST_URL}></meta>
         <meta

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,23 +9,24 @@ const Index = () => {
     <>
       <Head>
         <title>{METADATA.TITLE_SUFFIX}</title>
-        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
-        <meta property="og:type" content="website"></meta>
-        <meta property="og:url" content={METADATA.OXEN_HOST_URL}></meta>
-        <meta
-          property="og:title"
-          content={'Oxen - Privacy should be simple.'}
-          key="ogtitle"
-        />
         <meta
           name="description"
           content={NAVIGATION.SITE_META_DESCRIPTION}
         ></meta>
         <meta
+          property="og:title"
+          content={METADATA.TITLE_SUFFIX}
+          key="ogtitle"
+        />
+        <meta
           property="og:description"
           content={NAVIGATION.SITE_META_DESCRIPTION}
           key="ogdesc"
         />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
+        <meta property="og:url" content={METADATA.OXEN_HOST_URL} />
+
         <link rel="canonical" href="https://oxen.io/"></link>
       </Head>
 

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -41,6 +41,13 @@ function Roadmap() {
         <meta property="og:url" content={pageURL} />
 
         <link rel="canonical" href={pageURL}></link>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta
+          name="twitter:description"
+          content={METADATA.ROADMAP.DESCRIPTION}
+        />
+        <meta name="twitter:image" content={'site-banner.png'} />
       </Head>
 
       <div className="mx-4">

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -37,7 +37,6 @@ function Roadmap() {
           key="ogdesc"
         />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
         <meta property="og:url" content={pageURL} />
 
         <link rel="canonical" href={pageURL}></link>
@@ -47,7 +46,6 @@ function Roadmap() {
           name="twitter:description"
           content={METADATA.ROADMAP.DESCRIPTION}
         />
-        <meta name="twitter:image" content={'site-banner.png'} />
       </Head>
 
       <div className="mx-4">

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -1,9 +1,9 @@
 import Head from 'next/head';
 import React from 'react';
 import { useMeasure } from 'react-use';
-import { NAVIGATION } from '../constants';
+import { NAVIGATION, METADATA } from '../constants';
 import { SideMenuItem } from '../state/navigation';
-import { generateTitle } from '../utils/metadata';
+import { generateTitle, generateURL } from '../utils/metadata';
 
 function Roadmap() {
   const [ref, { width, height }] = useMeasure();
@@ -18,14 +18,29 @@ function Roadmap() {
   console.log('roadmap ➡️ width:', width);
   console.log('roadmap ➡️ ratio:', aspectRatio);
 
+  const pageTitle = generateTitle(
+    NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].label,
+  );
+  const pageURL = generateURL(
+    NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].href,
+  );
+
   return (
     <>
       <Head>
-        <title>
-          {generateTitle(
-            NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].label,
-          )}
-        </title>
+        <title>{pageTitle}</title>
+        <meta name="description" content={METADATA.ROADMAP.DESCRIPTION}></meta>
+        <meta property="og:title" content={pageTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={METADATA.ROADMAP.DESCRIPTION}
+          key="ogdesc"
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={'site-banner.png'} key="ogimage" />
+        <meta property="og:url" content={pageURL} />
+
+        <link rel="canonical" href={pageURL}></link>
       </Head>
 
       <div className="mx-4">

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -24,6 +24,7 @@ function Roadmap() {
   const pageURL = generateURL(
     NAVIGATION.SIDE_MENU_ITEMS[SideMenuItem.ROADMAP].href,
   );
+  const imageURL = `${METADATA.OXEN_HOST_URL}/site-banner.png`;
 
   return (
     <>
@@ -46,6 +47,7 @@ function Roadmap() {
           name="twitter:description"
           content={METADATA.ROADMAP.DESCRIPTION}
         />
+        <meta name="twitter:image" content={imageURL} />
       </Head>
 
       <div className="mx-4">

--- a/utils/metadata.ts
+++ b/utils/metadata.ts
@@ -6,3 +6,7 @@ export function generateTitle(prefix: string) {
     ? `${titleCase(prefix)} - ${METADATA.TITLE_SUFFIX}`
     : METADATA.TITLE_SUFFIX;
 }
+
+export function generateURL(prefix: string) {
+  return prefix ? `${METADATA.OXEN_HOST_URL}${prefix}` : METADATA.OXEN_HOST_URL;
+}


### PR DESCRIPTION
This PR adds a few missing metatags to every single webpage, improving our SEO ranking.
Most notably, 4 core metatags were missing:
-`description`
-`og:description`
-`og:url`
-`og:type`

By adding these 4 metatags, we're able to drastically improve our SEO score (from 12 to 100, according to ahrefs.com).

A few social metatags were added as well, such as:
```
<meta name="apple-itunes-app" content="app-id=1547745078" />
```
Which shows a download link to the Oxen Wallet app on iOS
and 
```
<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:title" content={pageTitle} />
<meta name="twitter:description" content={pageDescription} />
<meta name="twitter:image" content={page?.hero?.imageUrl} />Ï
```
Which changes how a link to an oxen.io webpage is displayed on Twitter, where previously no image was provided.
![image](https://user-images.githubusercontent.com/46293489/117105645-d217ca80-adc1-11eb-8d02-31056ca0e6c2.png)

 