### PR TITLE
Add CoinMarketCap Link and Logo

### DIFF
--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -80,7 +80,7 @@ export function SideMenuInner() {
         <div className="px-6 pb-3">
           <SocialsRow />
 
-          <div className="flex items-center justify-end font-medium text-secondary whitespace-nowrap">
+          <div className="flex items-center justify-between font-medium text-secondary whitespace-nowrap">
             View Oxen on{' '}
             <div className="flex items-center">
               <a
@@ -91,6 +91,15 @@ export function SideMenuInner() {
               >
                 <img className="h-5" src="/img/coingecko.png" />
                 <span>CoinGecko</span>
+              </a>
+              <a
+                href="https://coinmarketcap.com/currencies/oxen/"
+                target="_blank"
+                rel="nofollow"
+                className="flex items-center mx-2 space-x-1 font-bold hover:underline"
+              >
+                <img className="h-5" src="/img/coinmarketcap.png" />
+                <span>CMC</span>
               </a>
             </div>
           </div>

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -84,15 +84,6 @@ export function SideMenuInner() {
             View Oxen on{' '}
             <div className="flex items-center">
               <a
-                href="https://www.coingecko.com/en/coins/oxen"
-                target="_blank"
-                rel="nofollow"
-                className="flex items-center mx-2 space-x-1 font-bold hover:underline"
-              >
-                <img className="h-5" src="/img/coingecko.png" />
-                <span>CoinGecko</span>
-              </a>
-              <a
                 href="https://coinmarketcap.com/currencies/oxen/"
                 target="_blank"
                 rel="nofollow"
@@ -100,6 +91,15 @@ export function SideMenuInner() {
               >
                 <img className="h-5" src="/img/coinmarketcap.png" />
                 <span>CMC</span>
+              </a>
+              <a
+                href="https://www.coingecko.com/en/coins/oxen"
+                target="_blank"
+                rel="nofollow"
+                className="flex items-center mx-2 space-x-1 font-bold hover:underline"
+              >
+                <img className="h-5" src="/img/coingecko.png" />
+                <span>CoinGecko</span>
               </a>
             </div>
           </div>


### PR DESCRIPTION
This PR adds the previously removed CMC Link and Logo and makes the link a `nofollow` for SEO optimizations.

![image](https://user-images.githubusercontent.com/46293489/117241193-f0d79900-ae75-11eb-988c-55cbe41ac0b3.png)
