### PR TITLE
Update Blog Page Scrolling and Mobile SVG Icon Styling

### DIFF
--- a/components/cards/CardGrid.tsx
+++ b/components/cards/CardGrid.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function CardGrid({ rows, children }: Props) {
-  const { isMobile, isDesktop, isHuge } = useContext(ScreenContext);
+  const { isDesktop, isHuge } = useContext(ScreenContext);
 
   const [ref, { width }] = useMeasure();
   const widthOfCardPx = 200;
@@ -37,25 +37,7 @@ export function CardGrid({ rows, children }: Props) {
 
   return (
     <>
-      {isMobile ? (
-        <div className="">
-          <HorizontalScrollable>
-            {children.map(child => (
-              <div
-                key={uuid()}
-                style={{
-                  width: '80vw',
-                  minWidth: '275px',
-                  maxWidth: '330px',
-                }}
-                className="py-4"
-              >
-                {child}
-              </div>
-            ))}
-          </HorizontalScrollable>
-        </div>
-      ) : (
+      {
         <Contained>
           <div ref={ref} className={classNames('flex flex-col', spacingY)}>
             {_.chunk(cards, grouping).map(group => (
@@ -69,7 +51,7 @@ export function CardGrid({ rows, children }: Props) {
             ))}
           </div>
         </Contained>
-      )}
+      }
     </>
   );
 }

--- a/components/navigation/MobileHeader.tsx
+++ b/components/navigation/MobileHeader.tsx
@@ -60,8 +60,8 @@ export function MobileHeader() {
           <TriangleSVG
             onClick={() => toggleSideMenu()}
             className={classNames(
-              'h-3 fill-current text-primary transform outline-none duration-300 cursor-pointer',
-              sideMenuExpanded ? 'rotate-180' : '-rotate-60',
+              'h-4 fill-current text-primary transform outline-none duration-300 cursor-pointer',
+              sideMenuExpanded ? 'rotate-90' : '',
             )}
           />
         )}
@@ -71,8 +71,8 @@ export function MobileHeader() {
             <TriangleSVG
               onClick={() => toggleMobileMenu()}
               className={classNames(
-                'h-4 transform outline-none duration-300 cursor-pointer',
-                headerMobileMenuExpanded ? '-rotate-90' : 'rotate-90',
+                'h-4 fill-current text-primary transform outline-none duration-300 cursor-pointer',
+                headerMobileMenuExpanded ? 'rotate-90' : '',
               )}
             />
             <MobileMenu />


### PR DESCRIPTION
This PR updates the scrolling mechanism on the blog page, where it now uses vertical scrolling instead of the original horizontal scrolling.

Below is a gif file showcasing the changes:
![Screen Recording 2021-05-06 at 3 33 15 pm](https://user-images.githubusercontent.com/46293489/117247182-2c2b9500-ae81-11eb-92db-e6b32142a853.gif)

The styling for the triangle SVG button on the blog page has also been updated. Previously, the icon was hidden/not colored.
![Untitled](https://user-images.githubusercontent.com/46293489/117247686-18346300-ae82-11eb-9943-1e6bc862212c.gif)

