### PR TITLE
Remove Blog Preview Title Height Limit

### DIFF
--- a/components/cards/ArticleCard.tsx
+++ b/components/cards/ArticleCard.tsx
@@ -57,9 +57,6 @@ export function ArticleCard(props: IPost): JSX.Element {
           <Link href={href} as={as}>
             <a>
               <p
-                style={{
-                  maxHeight: '2em',
-                }}
                 className={classNames(
                   isSmall ? 'text-base' : 'text-lg',
                   'font-sans overflow-hidden cursor-pointer mb-3 hover:underline leading-none text-primary',


### PR DESCRIPTION
Issue:
Previously, blog preview titles would be truncated if the titles are too long.

![image](https://user-images.githubusercontent.com/46293489/118426803-44b46e80-b70f-11eb-99d4-c7b44eda01d1.png)

With this change, the full title will be shown.
![image](https://user-images.githubusercontent.com/46293489/118427277-2ef37900-b710-11eb-9207-45f602a6eca7.png)
