### PR TITLE
Add redirect to Monetisation & OXEN Value Capture Blog Post

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,16 @@ const nextConfig = {
     CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID,
     CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN,
   },
+  async redirects() {
+    return [
+      {
+        source: '/blog/session-the-road-to-monetisation-and-oxen-value-capture',
+        destination: '/blog/session-the-road-to-monetisation',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = withPlugins([withFonts, withSvgr], nextConfig);
+ 

--- a/next.config.js
+++ b/next.config.js
@@ -34,4 +34,3 @@ const nextConfig = {
 };
 
 module.exports = withPlugins([withFonts, withSvgr], nextConfig);
- 


### PR DESCRIPTION
Issue: 
Users would be redirected to the 404 Page every time they navigate to https://oxen.io/blog/session-the-road-to-monetisation-and-oxen-value-capture. This link has been deprecated, but links to this page still exist in various other websites, so an redirect is needed here for better SEO and UI/UX.

This PR simply adds a redirect each time the user navigates to the `/blog/session-the-road-to-monetisation-and-oxen-value-capture` route.

Users will be redirected to the correct `/blog/session-the-road-to-monetisation` page.

Quick test: 
OLD URL: https://oxen-website-test-j09buhr5i-lucasphang.vercel.app/blog/session-the-road-to-monetisation-and-oxen-value-capture
should redirect you to the new url instead of the 404 page:
https://oxen-website-test-j09buhr5i-lucasphang.vercel.app/blog/session-the-road-to-monetisation