### PR TITLE
Update FAQ Page Styling

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -170,7 +170,6 @@ ul li > p {
   margin-bottom: 0 !important;
 }
 
-
 .accordion-content {
   transition: max-height 0.2s;
 }

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -171,17 +171,13 @@ ul li > p {
 }
 
 .accordion {
-  background-color: theme('colors.secondary');
-  color: theme('colors.primary');
+
   cursor: pointer;
   padding: 0.5em;
   width: 100%;
   text-align: left;
 }
 
-.accordion:hover {
-  filter: brightness(0.9);
-}
 
 .accordion-content {
   transition: max-height 0.2s;

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -170,16 +170,7 @@ ul li > p {
   margin-bottom: 0 !important;
 }
 
-.accordion {
-
-  cursor: pointer;
-  padding: 0.5em;
-  width: 100%;
-  text-align: left;
-}
-
 
 .accordion-content {
   transition: max-height 0.2s;
-  overflow: hidden;
 }

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -17,9 +17,10 @@ export function Accordion(props) {
   return (
     <div className="mb-1 border border-current rounded-sm">
       <button
-        className={
-          'flex accordion text-xl tablet:text-2xl  w-full text-left	bg-secondary px-3 justify-between items-center'
-        }
+        className={classNames(
+          'flex accordion text-xl tablet:text-2xl  w-full text-left px-3 justify-between items-center hover:bg-secondary',
+          isActive ? 'bg-secondary' : '',
+        )}
         onClick={toggleAccordion}
       >
         <div style={{ maxWidth: '95%' }}> {question}</div>

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -18,12 +18,12 @@ export function Accordion(props) {
     <div className="mb-1 border border-current rounded-sm">
       <button
         className={classNames(
-          'flex accordion text-xl tablet:text-2xl  w-full text-left px-3 justify-between items-center hover:bg-secondary',
+          'flex accordion text-xl tablet:text-2xl w-full text-left justify-between items-center hover:bg-secondary cursor-pointer py-3 px-6',
           isActive ? 'bg-secondary' : '',
         )}
         onClick={toggleAccordion}
       >
-        <div style={{ maxWidth: '95%' }}> {question}</div>
+        <div style={{ maxWidth: '90%' }}>{question}</div>
         <TriangleSVG
           className={classNames(
             'h-3 fill-current text-primary transform outline-none cursor-pointer duration-200',
@@ -36,7 +36,7 @@ export function Accordion(props) {
         style={{
           maxHeight: height,
         }}
-        className={classNames('accordion-content')}
+        className={classNames('accordion-content overflow-hidden')}
       >
         <div className="w-full px-4 pt-4 text-lg text-left ease-in-out tablet:text-xl">
           <RichBody body={answer} />

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -24,7 +24,7 @@ export function Accordion(props) {
       <button
         ref={button}
         className={classNames(
-          'flex accordion text-xl tablet:text-2xl w-full text-left justify-between items-center hover:bg-secondary duration-300 cursor-pointer py-3 px-6',
+          'flex text-xl tablet:text-2xl w-full text-left justify-between items-center hover:bg-secondary duration-300 cursor-pointer py-3 px-6',
           isActive ? 'bg-secondary' : '',
         )}
         onClick={toggleAccordion}

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef } from 'react';
 import { RichBody } from '../components/RichBody';
 import classNames from 'classnames';
-import TriangleSVG from '../assets/svgs/triangle.svg';
+import TriangleOutlinedSVG from '../assets/svgs/triangle-outlined.svg';
+import { useHoverDirty } from 'react-use';
 
 export function Accordion(props) {
   const { question, answer } = props;
@@ -9,6 +10,10 @@ export function Accordion(props) {
   const [height, setHeight] = useState('0px');
 
   const content = useRef(null);
+  const button = useRef(null);
+  const isHovering = useHoverDirty(button);
+  const isExcited = isActive || isHovering;
+
   function toggleAccordion() {
     setActiveState(!isActive);
     setHeight(isActive ? '0px' : `${content.current.scrollHeight}px`);
@@ -17,17 +22,19 @@ export function Accordion(props) {
   return (
     <div className="mb-1 border border-current rounded-sm">
       <button
+        ref={button}
         className={classNames(
-          'flex accordion text-xl tablet:text-2xl w-full text-left justify-between items-center hover:bg-secondary cursor-pointer py-3 px-6',
+          'flex accordion text-xl tablet:text-2xl w-full text-left justify-between items-center hover:bg-secondary duration-300 cursor-pointer py-3 px-6',
           isActive ? 'bg-secondary' : '',
         )}
         onClick={toggleAccordion}
       >
         <div style={{ maxWidth: '90%' }}>{question}</div>
-        <TriangleSVG
+        <TriangleOutlinedSVG
           className={classNames(
-            'h-3 fill-current text-primary transform outline-none cursor-pointer duration-200',
+            'h-3 fill-current transform outline-none cursor-pointer duration-300 text-transparent',
             isActive ? 'rotate-90' : '',
+            isExcited ? 'text-primary' : '',
           )}
         />{' '}
       </button>

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -64,7 +64,7 @@ const SIDE_MENU_ITEMS = {
   },
   [SideMenuItem.FAQ]: {
     id: 9,
-    label: 'Frequently Asked Questions',
+    label: 'FAQ',
     href: '/faq',
   },
 } as { [name: string]: ISideMenuItem };


### PR DESCRIPTION
This PR makes some styling changes to the FAQ Accordion component, such that it is more consistent with the designs currently used by the Side Menu Component.

![image](https://user-images.githubusercontent.com/46293489/118759843-212b2880-b8b5-11eb-9c42-366124db468a.png)

![image](https://user-images.githubusercontent.com/46293489/118759871-27b9a000-b8b5-11eb-9a21-3a44661ebc1a.png)

Some notable changes include:
- Updating FAQ label from 'Frequently Asked Questions' to 'FAQ'
- Setting background color of the accordion to be transparent
- Updating background color of the accordion on hover/on open
- Removing redundant CSS code