### PR TITLE
Improve Blog Page Pagination

### DIFF
--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -111,6 +111,13 @@ const Blog = (props: Props) => {
     });
   };
 
+  // Mobile Pagination Settings
+  const MAX_PAGINATION_BUTTONS_MOBILE = 5; // On mobile, we want to only have a maximum of 5 pagination buttons
+  const hasTooManyButtons =
+    isMobile && pageCount > MAX_PAGINATION_BUTTONS_MOBILE; // Check if the maximum number of pagination buttons have been reached
+  const EDGE_PAGES = [1, 2, pageCount - 1, pageCount]; // Check if the current page is an edge page, to keep the number of pagination buttons consistent
+  const isEdgePage = isMobile && EDGE_PAGES.includes(currentPage);
+
   const pagination = (
     <Contained>
       <div className="flex justify-center mb-4">
@@ -124,8 +131,8 @@ const Blog = (props: Props) => {
             containerClassName={'pagination bg-primary text-white front-prompt'}
             initialPage={currentPage - 1}
             pageCount={pageCount}
-            marginPagesDisplayed={isMobile ? 1 : 2}
-            pageRangeDisplayed={1}
+            marginPagesDisplayed={hasTooManyButtons && !isEdgePage ? 1 : 2}
+            pageRangeDisplayed={isMobile ? 1 : 2}
             onPageChange={paginationHandler}
           />
         </div>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import ReactPaginate from 'react-paginate';
 import { useDispatch } from 'react-redux';
 import { ArticleCard } from '../../components/cards/ArticleCard';
@@ -14,6 +14,7 @@ import { CmsApi } from '../../services/cms';
 import { PageType, setPageType } from '../../state/navigation';
 import { IPost } from '../../types/cms';
 import { generateTitle } from '../../utils/metadata';
+import { ScreenContext } from '../../contexts/screen';
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const cms = new CmsApi();
@@ -81,6 +82,7 @@ interface Props {
 
 const Blog = (props: Props) => {
   const { posts, tagPosts, tag, currentPage, pageCount } = props;
+  const { isMobile } = useContext(ScreenContext);
 
   const router = useRouter();
   const dispatch = useDispatch();
@@ -122,8 +124,8 @@ const Blog = (props: Props) => {
             containerClassName={'pagination bg-primary text-white front-prompt'}
             initialPage={currentPage - 1}
             pageCount={pageCount}
-            marginPagesDisplayed={1}
-            pageRangeDisplayed={2}
+            marginPagesDisplayed={isMobile ? 1 : 2}
+            pageRangeDisplayed={1}
             onPageChange={paginationHandler}
           />
         </div>

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -12,9 +12,6 @@ import { Contained } from '../components/Contained';
 export const getServerSideProps: GetServerSideProps = async context => {
   const cms = new CmsApi();
 
-  // Fetch posts even when tag, for related etc
-  // Pagination only occurs when tag isnt defined.
-  // If tag is defined, pagination is for tag results
   const { faqItems, total } = await cms.fetchFAQItems();
 
   return {


### PR DESCRIPTION
### Issues
Previously, there were a few issues/inconsistencies with the pagination component on the blog page.
For example, in the image below, we can see that the break symbol (`...`) was used in the pagination button, despite there being only 4 pages.
![image](https://user-images.githubusercontent.com/46293489/119297508-6c22b280-bc9e-11eb-9163-5fd979296139.png)

Which is inconsistent with what the pagination buttons look like on other pages, like the image below

![image](https://user-images.githubusercontent.com/46293489/119297578-9c6a5100-bc9e-11eb-90db-4ee1f331fa91.png)

Another issue that was found was that the pagination view on smaller mobile phones goes beyond the boundaries of the page.

![image](https://user-images.githubusercontent.com/46293489/119297810-0d116d80-bc9f-11eb-8d96-c398b7148f9f.png)

### Description
To address these issue, we need to dynamically set the properties of the pagination component, based on the current page, the total number of pages, and the device type.

On non-mobile devices, we increase the number of buttons on each end of the component (also known as `marginPageDisplayed`), as well as the the number of buttons in the middle of the component (`pageRangeDisplayed`), which fixes the first aforementioned issue.

![image](https://user-images.githubusercontent.com/46293489/119298262-00414980-bca0-11eb-9ac9-97161e9cba01.png)

On mobile devices, we want to ensure that the number of pagination buttons remain consistent when there are a lot of pages, with 5 being the ideal number here. By doing this, we ensure that the component doesn't go beyond the page's boundary, and consistency between the pages.

Below are a few examples of the pagination component on mobile

![image](https://user-images.githubusercontent.com/46293489/119298564-9b3a2380-bca0-11eb-8084-ad07391f2a6f.png)
![image](https://user-images.githubusercontent.com/46293489/119298575-a2f9c800-bca0-11eb-8213-54152f08cab7.png)
![image](https://user-images.githubusercontent.com/46293489/119298588-ae4cf380-bca0-11eb-9a16-9cbdd8bdfe3b.png)
![image](https://user-images.githubusercontent.com/46293489/119298716-e94f2700-bca0-11eb-924b-61491313a3b4.png)


