### PR TITLE
Resize Blog Hero Image to Full Width

### DIFF
--- a/components/article/Article.tsx
+++ b/components/article/Article.tsx
@@ -26,12 +26,7 @@ export function Article(props: IPost) {
   return (
     <article>
       <div className="flex flex-col items-center mt-10 mb-16 space-y-4">
-        <Contained>
-          <ArticleSectionFeatureImage
-            featureImage={featureImage}
-            title={title}
-          />
-        </Contained>
+        <ArticleSectionFeatureImage featureImage={featureImage} title={title} />
 
         <ArticleContained>
           <div className="flex flex-col mb-6 space-y-6">

--- a/components/article/sections/ArticleSectionFeatureImage.tsx
+++ b/components/article/sections/ArticleSectionFeatureImage.tsx
@@ -1,4 +1,6 @@
 import { IFigureImage } from '../../../types/cms';
+import { Contained } from '../../Contained';
+import { ArticleContained } from '../../ArticleContained';
 
 interface Props {
   featureImage: IFigureImage;
@@ -8,18 +10,23 @@ interface Props {
 export function ArticleSectionFeatureImage({ featureImage, title }: Props) {
   return (
     <div className="w-full pb-4 desktop:pb-0">
-      <div className="relative w-full max-h-full mb-4 md:max-h-screen">
+      <div className="relative flex items-center justify-center w-full h-full bg-gradient-to-bl from-hyper to-blush">
         <img
           src={featureImage?.imageUrl}
           alt={featureImage?.description ?? title}
+          style={{ maxHeight: '65vh', width: '87.5em' }}
           className="object-fill"
         />
       </div>
 
       {featureImage?.description && (
-        <div className="w-8/12 pl-2 text-sm italic">
-          {featureImage?.description}
-        </div>
+        <Contained>
+          <ArticleContained>
+            <div className="pt-2 italic ext-sm">
+              {featureImage?.description}
+            </div>
+          </ArticleContained>
+        </Contained>
       )}
     </div>
   );

--- a/components/article/sections/ArticleSectionFeatureImage.tsx
+++ b/components/article/sections/ArticleSectionFeatureImage.tsx
@@ -8,16 +8,18 @@ interface Props {
 export function ArticleSectionFeatureImage({ featureImage, title }: Props) {
   return (
     <div className="w-full pb-4 desktop:pb-0">
-      <div className="relative w-full mb-4 aspect-w-14 aspect-h-8">
+      <div className="relative w-full max-h-full mb-4 md:max-h-screen">
         <img
           src={featureImage?.imageUrl}
           alt={featureImage?.description ?? title}
-          className="object-cover rounded"
+          className="object-fill"
         />
       </div>
 
       {featureImage?.description && (
-        <div className="w-8/12 text-sm italic">{featureImage?.description}</div>
+        <div className="w-8/12 pl-2 text-sm italic">
+          {featureImage?.description}
+        </div>
       )}
     </div>
   );

--- a/components/article/sections/ArticleSectionFeatureImage.tsx
+++ b/components/article/sections/ArticleSectionFeatureImage.tsx
@@ -10,11 +10,10 @@ interface Props {
 export function ArticleSectionFeatureImage({ featureImage, title }: Props) {
   return (
     <div className="w-full pb-4 desktop:pb-0">
-      <div className="relative flex items-center justify-center w-full h-full bg-gradient-to-bl from-hyper to-blush">
+      <div className="relative flex items-center justify-center w-full h-full">
         <img
           src={featureImage?.imageUrl}
           alt={featureImage?.description ?? title}
-          style={{ maxHeight: '65vh', width: '87.5em' }}
           className="object-fill"
         />
       </div>


### PR DESCRIPTION
This PR adjusts the width of the blog image to take the entire screen, inspired by designs on https://thereboot.com/fixing-techs-design-problem/

Below are a few screenshots in various screen sizes

1280 px 
![image](https://user-images.githubusercontent.com/46293489/123766886-69088b00-d90a-11eb-9c91-77095ac407cb.png)

Widescreen
![image](https://user-images.githubusercontent.com/46293489/123767740-0e236380-d90b-11eb-9d94-359ee7d57158.png)


Tablet
![image](https://user-images.githubusercontent.com/46293489/123767592-efbd6800-d90a-11eb-956d-b02d1b21f7ae.png)

Mobile
![image](https://user-images.githubusercontent.com/46293489/123767869-285d4180-d90b-11eb-8c0b-c07f2403741e.png)

