### PR TITLE
Revert image placeholders for smaller images

### DIFF
--- a/components/cards/ArticleCard.tsx
+++ b/components/cards/ArticleCard.tsx
@@ -50,8 +50,6 @@ export function ArticleCard(props: IPost): JSX.Element {
             src={`${featureImage?.imageUrl}?w=300`}
             alt={featureImage?.description ?? title}
             layout="fill"
-            placeholder="blur"
-            blurDataURL={`${featureImage?.imageUrl}?w=300&q=5`}
             className="object-cover"
           />
         )}

--- a/components/cards/ArticleCardFeature.tsx
+++ b/components/cards/ArticleCardFeature.tsx
@@ -45,8 +45,6 @@ export function ArticleCardFeature(props: IPost) {
             alt={featureImage?.description ?? title}
             layout="fill"
             priority={true}
-            placeholder="blur"
-            blurDataURL={`${featureImage?.imageUrl}?w=600&q=5`}
             className="object-cover"
           />
         </div>

--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -105,12 +105,7 @@ export function SideMenuInner() {
               className="flex items-center space-x-1 hover:underline hover:text-secondary"
             >
               <div className="relative w-5 h-5">
-                <Image
-                  src={CoinMarketCapImage}
-                  alt="CMC logo"
-                  layout="fill"
-                  placeholder="blur"
-                />
+                <Image src={CoinMarketCapImage} alt="CMC logo" layout="fill" />
               </div>
               <span>CMC</span>
             </a>
@@ -125,7 +120,6 @@ export function SideMenuInner() {
                   src={CoinGeckoImage}
                   alt="CoinGecko logo"
                   layout="fill"
-                  placeholder="blur"
                 />
               </div>
               <span>CoinGecko</span>


### PR DESCRIPTION
- Blur placeholders keep loading when you go back from a blog post. This blurring decreases perceived performance of the site. So we will only use blurring for large header images.