### PR TITLE
Preview route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 # misc
 .DS_Store
 .env*
+.vscode
 
 # debug
 npm-debug.log*

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
   env: {
     CONTENTFUL_SPACE_ID: process.env.CONTENTFUL_SPACE_ID,
     CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_ACCESS_TOKEN,
+    CONTENTFUL_PREVIEW_TOKEN: process.env.CONTENTFUL_PREVIEW_TOKEN,
+    CAMPAIGN_MONITOR_CLIENT_ID: process.env.CAMPAIGN_MONITOR_CLIENT_ID,
+    CAMPAIGN_MONITOR_API_KEY: process.env.CAMPAIGN_MONITOR_API_KEY,
+    CAMPAIGN_MONITOR_LIST_API_ID: process.env.CAMPAIGN_MONITOR_LIST_API_ID,
   },
   images: {
     domains: ['downloads.ctfassets.net', 'images.ctfassets.net'],

--- a/pages/preview/[...slug].tsx
+++ b/pages/preview/[...slug].tsx
@@ -36,7 +36,7 @@ export default function Preview(props: Props): ReactElement {
 export const getServerSideProps: GetServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
-  let slug = context.params?.slug.toString() ?? '';
+  const slug = context.params?.slug.toString().split(',').join('/') ?? '';
   const id = unslugify(slug);
   console.log(`Loading Preview %c${slug}`, 'color: purple;');
   try {
@@ -44,10 +44,11 @@ export const getServerSideProps: GetServerSideProps = async (
     let page: ISplitPage | IPost;
 
     if (SideMenuItem[id]) {
-      page = await cms.fetchPageById(SideMenuItem[id], true);
+      page = await cms.fetchEntryPreview(SideMenuItem[id], 'splitPage');
     } else {
-      if (slug.indexOf('blog,') >= 0) slug = slug.split('blog,')[1];
-      page = await cms.fetchEntryBySlug(slug, 'post', true);
+      let query = slug;
+      if (slug.indexOf('blog/') >= 0) query = slug.split('blog/')[1];
+      page = await cms.fetchEntryPreview(query, 'post');
       // embedded links in post body need metadata for preview
       page.body = await generateLinkMeta(page.body);
     }

--- a/services/cms.tsx
+++ b/services/cms.tsx
@@ -26,8 +26,9 @@ import isLive from '../utils/environment';
 import { generateURL } from '../constants/metadata';
 import { fetchContent } from './embed';
 
-function loadOptions(options: any) {
-  if (isLive()) options['fields.live'] = true;
+function loadOptions(options: any, isPreview?: boolean) {
+  if (!isPreview && isLive()) options['fields.live'] = true;
+  if (isPreview) options['fields.preview'] = true;
   return options;
 }
 
@@ -175,11 +176,17 @@ export class CmsApi {
   public async fetchEntryBySlug(
     slug: string,
     entryType: 'post' | 'splitPage',
+    isPreview?: boolean,
   ): Promise<any> {
-    const _entries = await this.client.getEntries({
-      content_type: entryType, // only fetch specific type
-      'fields.slug': slug,
-    });
+    const _entries = await this.client.getEntries(
+      loadOptions(
+        {
+          content_type: entryType, // only fetch specific type
+          'fields.slug': slug,
+        },
+        isPreview,
+      ),
+    );
 
     if (_entries?.items?.length > 0) {
       let entry;
@@ -201,13 +208,19 @@ export class CmsApi {
     );
   }
 
-  public async fetchPageById(id: SideMenuItem): Promise<ISplitPage> {
+  public async fetchPageById(
+    id: SideMenuItem,
+    isPreview?: boolean,
+  ): Promise<ISplitPage> {
     return this.client
       .getEntries(
-        loadOptions({
-          content_type: 'splitPage',
-          'fields.id[in]': id,
-        }),
+        loadOptions(
+          {
+            content_type: 'splitPage',
+            'fields.id[in]': id,
+          },
+          isPreview,
+        ),
       )
       .then(entries => {
         if (entries && entries.items && entries.items.length > 0) {


### PR DESCRIPTION
- Added `preview/` route for previewing content from Contentful even if it's in a draft state.
- This will most likely replace the live 🚀 feature in the future.