### PR TITLE
Replace sessiongroups.com reference with sessioncommunities.online

### DIFF
--- a/components/navigation/SideMenuInner.tsx
+++ b/components/navigation/SideMenuInner.tsx
@@ -172,7 +172,7 @@ const SocialsRow = () => {
       >
         <RedditSVG className="h-10 placeholder-current duration-300 border rounded-full cursor-pointer fill-current stroke-current hover:bg-primary hover:text-secondary border-primary" />
       </a>
-      <a href="https://sessiongroups.com/" target="_blank" rel="noreferrer">
+      <a href="https://sessioncommunities.online/" target="_blank" rel="noreferrer">
         <SessionSVG className="h-10 placeholder-current duration-300 border rounded-full cursor-pointer fill-current stroke-current hover:bg-primary hover:text-secondary border-primary" />
       </a>
       <Link href="/feed">


### PR DESCRIPTION
The current Session icon links to https://sessiongroups.com/, an outdated and very incomplete Session Communities aggregator.

This commit replaces the link with https://sessioncommunities.online/, a maintained Session Communities aggregator that automatically fetches several sources.

(Please excuse the borked commit message.)