### PR TITLE
fix: create blog redirect map

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const ContentSecurityPolicy = `
   worker-src 'self' blob:;
 `;
 
-function redirectPosts(postNameMap) {
+function redirectSessionTokenPosts(postNameMap) {
   return postNameMap.flatMap(({ source, destination }) => {
     return ['', '/blog'].map(prefix => ({
       source: `${prefix}${source}`,
@@ -103,7 +103,7 @@ const nextConfig = {
         destination: '/blog/new-leadership-new-possibilities',
         permanent: true,
       },
-      ...redirectPosts([
+      ...redirectSessionTokenPosts([
         {
           source: '/session-token-utility',
           destination: '/say-hello-to-session-token',

--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,16 @@ const ContentSecurityPolicy = `
   worker-src 'self' blob:;
 `;
 
+function redirectPosts(postNameMap) {
+  return postNameMap.flatMap(({ source, destination }) => {
+    return ['', '/blog'].map(prefix => ({
+      source: `${prefix}${source}`,
+      destination: `https://token.getsession.org/blog${destination}`,
+      permanent: true,
+    }));
+  });
+}
+
 const securityHeaders = () => {
   const headers = [
     {
@@ -93,7 +103,7 @@ const nextConfig = {
         destination: '/blog/new-leadership-new-possibilities',
         permanent: true,
       },
-      ...[
+      ...redirectPosts([
         {
           source: '/session-token-utility',
           destination: '/say-hello-to-session-token',
@@ -102,13 +112,7 @@ const nextConfig = {
           source: '/genesis-distribution',
           destination: '/session-token-genesis-distribution',
         },
-      ].flatMap(({ source, destination }) => {
-        return ['', '/blog'].map(prefix => ({
-          source: `${prefix}${source}`,
-          destination: `https://token.getsession.org/blog${destination}`,
-          permanent: true,
-        }));
-      }),
+      ]),
     ],
   },
   async redirects() {

--- a/next.config.js
+++ b/next.config.js
@@ -93,18 +93,22 @@ const nextConfig = {
         destination: '/blog/new-leadership-new-possibilities',
         permanent: true,
       },
-      {
-        source: '/blog/session-token-utility',
-        destination:
-          'https://token.getsession.org/blog/say-hello-to-session-token',
-        permanent: true,
-      },
-      {
-        source: '/blog/genesis-distribution',
-        destination:
-          'https://token.getsession.org/blog/session-token-genesis-distribution',
-        permanent: true,
-      },
+      ...[
+        {
+          source: '/session-token-utility',
+          destination: '/say-hello-to-session-token',
+        },
+        {
+          source: '/genesis-distribution',
+          destination: '/session-token-genesis-distribution',
+        },
+      ].flatMap(({ source, destination }) => {
+        return ['', '/blog'].map(prefix => ({
+          source: `${prefix}${source}`,
+          destination: `https://token.getsession.org/blog${destination}`,
+          permanent: true,
+        }));
+      }),
     ],
   },
   async redirects() {


### PR DESCRIPTION
Rewrite blog redirects to use a map that can be used for future redirects to the session token website